### PR TITLE
allow alternative redisClient to be specified in the options

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ exports.register = function(server, options, next) {
         server.log(['info', pkg.name], 'Redis Connection Closed');
       });
     }
-    request.redis = redisClient; // assign once
+    request.redis = options.redisClient || redisClient; // assign once
     reply.continue()
   });
   next();


### PR DESCRIPTION
Hey,

at this stage, this is more of an idea than an actual pull request. I do think this would be useful.

Basically, I think we should be able to define an alternative redis client in the plugin options. Why? If you're using something like redis-mock in your tests, you need to be able to have hapi-redis-connection deliver that mock, not the actual redis option.

The downside of this super simple approach is that we still do `require("redis-connection")`.

With this patch, you can do:

```
import * as redisMock from 'redis-mock'

const redis = redisMock.createClient()

beforeEach(() => {
    server = new hapi.Server()
    server.connection({ port: 8888 })
    server.register([
      {
        register: require('hapi-redis-connection'),
        options: {
          redisClient: redis
        }
      },
      ...
    ])
    redis.flushall()
})
```

(Sorry about Typescript)